### PR TITLE
Add task for generating zip

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,16 @@ task copyToLib(type: Copy){
     from configurations.runtime
 }
 
+task generate_zip(type: Zip) {
+   description 'Generates a zip file containing the docs and libs directories.'
+   from "$buildDir"
+   include('libs/', 'docs/')
+   archiveName "saidp-sdk-java-${version}.zip"
+}
+
 build.dependsOn(copyToLib)
 build.dependsOn(javadoc)
+generate_zip.dependsOn(build)
 
 task wrapper(type: Wrapper) {
     gradleVersion = '2.7'


### PR DESCRIPTION
This `generate_zip` task will perform the zip operation.  The resulting archive will land in the default location `build/distributions`.