### PR TITLE
Access restriction: The type 'MappingChange<E,F>' is not API

### DIFF
--- a/src/main/java/org/secureauth/sarestapi/data/IPEvaluation.java
+++ b/src/main/java/org/secureauth/sarestapi/data/IPEvaluation.java
@@ -1,7 +1,6 @@
 package org.secureauth.sarestapi.data;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.sun.javafx.collections.MappingChange;
 import org.secureauth.sarestapi.util.JSONUtil;
 
 


### PR DESCRIPTION
The SDK does not compile in Eclipse due to the following error:

Access restriction: The type 'MappingChange<E,F>' is not API (restriction on required library '/opt/jdk1.8.0_74/jre/lib/ext/jfxrt.jar')

This check can be disabled or downgraded to a warning in Eclipse's preferences but since the import is not actually used, it seems easier to remove it from the code.