### PR TITLE
Moved Custom Header for Millisecond to the Client Filter

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-currentVersion=1.0.3.1-SNAPSHOT
+currentVersion=1.0.3.2-SNAPSHOT

--- a/src/main/java/org/secureauth/sarestapi/SAAccess.java
+++ b/src/main/java/org/secureauth/sarestapi/SAAccess.java
@@ -1146,7 +1146,7 @@ public class SAAccess {
     String getServerTime() {
         Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         SimpleDateFormat dateFormat = new SimpleDateFormat(
-                "EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
+                "EEE, dd MMM yyyy HH:mm:ss.SSS z", Locale.US);
         dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
         return dateFormat.format(calendar.getTime());
     }

--- a/src/main/java/org/secureauth/sarestapi/filters/SACheckRequestFilter.java
+++ b/src/main/java/org/secureauth/sarestapi/filters/SACheckRequestFilter.java
@@ -25,6 +25,7 @@ public class SACheckRequestFilter implements ClientRequestFilter {
         if(!requestContext.getHeaders().containsKey("X-SA-Ext-Date")){
             requestContext.getHeaders().add("X-SA-Ext-Date", getServerTimeMs());
         }
+        //Technically we should never get this point
         if (!requestContext.getHeaders().containsKey("X-SA-Date") && !requestContext.getHeaders().containsKey("X-SA-Ext-Date")){
             requestContext.abortWith(Response.status(Response.Status.BAD_REQUEST).entity("X-SA-Date or X-SA-Ext-Date header must be defined.").build());
         }
@@ -39,6 +40,7 @@ public class SACheckRequestFilter implements ClientRequestFilter {
         return dateFormat.format(calendar.getTime());
     }
 
+    //Just in case we want to force the second version timestamp for older versions of IDP
     String getServerTimeSeconds() {
         Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         SimpleDateFormat dateFormat = new SimpleDateFormat(

--- a/src/main/java/org/secureauth/sarestapi/filters/SACheckRequestFilter.java
+++ b/src/main/java/org/secureauth/sarestapi/filters/SACheckRequestFilter.java
@@ -2,8 +2,13 @@ package org.secureauth.sarestapi.filters;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.TimeZone;
 
 /**
  * Created by rrowcliffe on 5/6/16.
@@ -15,8 +20,30 @@ public class SACheckRequestFilter implements ClientRequestFilter {
         if (requestContext.getHeaders().get("Authorization") == null) {
             requestContext.abortWith(Response.status(Response.Status.BAD_REQUEST).entity("Authorization header must be defined.").build());
         }
-        if (requestContext.getHeaders().get("X-SA-Date") == null) {
-            requestContext.abortWith(Response.status(Response.Status.BAD_REQUEST).entity("X-SA-Date header must be defined.").build());
+
+        //Moved all TimeStamp Header setting to Filter Controlled
+        if(!requestContext.getHeaders().containsKey("X-SA-Ext-Date")){
+            requestContext.getHeaders().add("X-SA-Ext-Date", getServerTimeMs());
         }
+        if (!requestContext.getHeaders().containsKey("X-SA-Date") && !requestContext.getHeaders().containsKey("X-SA-Ext-Date")){
+            requestContext.abortWith(Response.status(Response.Status.BAD_REQUEST).entity("X-SA-Date or X-SA-Ext-Date header must be defined.").build());
+        }
+
+    }
+
+    String getServerTimeMs() {
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        SimpleDateFormat dateFormat = new SimpleDateFormat(
+                "EEE, dd MMM yyyy HH:mm:ss.SSS z", Locale.US);
+        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+        return dateFormat.format(calendar.getTime());
+    }
+
+    String getServerTimeSeconds() {
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        SimpleDateFormat dateFormat = new SimpleDateFormat(
+                "EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
+        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+        return dateFormat.format(calendar.getTime());
     }
 }

--- a/src/main/java/org/secureauth/sarestapi/resources/SAExecuter.java
+++ b/src/main/java/org/secureauth/sarestapi/resources/SAExecuter.java
@@ -130,7 +130,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     get();
             genericResponse = response.readEntity(valueType);
             response.close();
@@ -161,7 +160,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", header).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(authRequest),MediaType.APPLICATION_JSON));
 
             responseObject = response.readEntity(BaseResponse.class);
@@ -191,7 +189,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(authRequest), MediaType.APPLICATION_JSON));
             responseObject=response.readEntity(BaseResponse.class);
             response.close();
@@ -220,7 +217,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(authRequest), MediaType.APPLICATION_JSON));
             responseObject=response.readEntity(BaseResponse.class);
             response.close();
@@ -249,7 +245,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(authRequest), MediaType.APPLICATION_JSON));
 
             responseObject=response.readEntity(BaseResponse.class);
@@ -279,7 +274,6 @@ public class SAExecuter {
             response = target.request()
                     .accept(MediaType.APPLICATION_JSON).
                             header("Authorization", auth).
-                            header("X-SA-Date", ts).
                             post(Entity.entity(JSONUtil.convertObjectToJSON(authRequest), MediaType.APPLICATION_JSON));
 
             responseObject=response.readEntity(BaseResponse.class);
@@ -310,7 +304,6 @@ public class SAExecuter {
                     accept(MediaType.APPLICATION_JSON).
                     //type(MediaType.APPLICATION_JSON).
                             header("Authorization", auth).
-                            header("X-SA-Date", ts).
                             post(Entity.entity(JSONUtil.convertObjectToJSON(authRequest), MediaType.APPLICATION_JSON));
 
             responseObject=response.readEntity(ResponseObject.class);
@@ -341,7 +334,6 @@ public class SAExecuter {
             response = target.request()
                     .accept(MediaType.APPLICATION_JSON).
                             header("Authorization", auth).
-                            header("X-SA-Date", ts).
                             post(Entity.entity(JSONUtil.convertObjectToJSON(authRequest), MediaType.APPLICATION_JSON));
 
             responseObject=response.readEntity(ResponseObject.class);
@@ -371,7 +363,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(authRequest), MediaType.APPLICATION_JSON));
 
             responseObject=response.readEntity(ResponseObject.class);
@@ -402,7 +393,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(authRequest),MediaType.APPLICATION_JSON));
 
             responseObject=response.readEntity(valueType);
@@ -432,7 +422,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(validateOTPRequest),MediaType.APPLICATION_JSON));
 
             validateOTPResponse = response.readEntity(ValidateOTPResponse.class);
@@ -463,7 +452,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(authRequest),MediaType.APPLICATION_JSON));
 
             responseObject=response.readEntity(ResponseObject.class);
@@ -498,7 +486,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(ipEvalRequest), MediaType.APPLICATION_JSON));
 
             ipEval = response.readEntity(IPEval.class);
@@ -529,7 +516,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(accessHistoryRequest),MediaType.APPLICATION_JSON));
 
             accessHistory = response.readEntity(ResponseObject.class);
@@ -559,7 +545,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(dfpValidateRequest),MediaType.APPLICATION_JSON));
 
             dfpValidateResponse = response.readEntity(DFPValidateResponse.class);
@@ -589,7 +574,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(dfpConfirmRequest),MediaType.APPLICATION_JSON));
 
 
@@ -620,7 +604,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     get();
             jsObjectResponse = response.readEntity(valueType);
             response.close();
@@ -649,7 +632,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(behaveBioRequest),MediaType.APPLICATION_JSON));
 
             behaveBioResponse = response.readEntity(BehaveBioResponse.class);
@@ -680,7 +662,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     put(Entity.entity(JSONUtil.convertObjectToJSON(behaveBioResetRequest),MediaType.APPLICATION_JSON));
 
             behaveBioResponse = response.readEntity(ResponseObject.class);
@@ -711,7 +692,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(userPasswordRequest),MediaType.APPLICATION_JSON));
 
             passwordResetResponse = response.readEntity(ResponseObject.class);
@@ -742,7 +722,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(userPasswordRequest),MediaType.APPLICATION_JSON));
 
             passwordChangeResponse = response.readEntity(ResponseObject.class);
@@ -773,7 +752,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     put(Entity.entity(JSONUtil.convertObjectToJSON(userProfile), MediaType.APPLICATION_JSON));
 
             responseObject=response.readEntity(valueType);
@@ -803,7 +781,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(newUserProfile),MediaType.APPLICATION_JSON));
 
             responseObject=response.readEntity(valueType);
@@ -832,7 +809,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity("",MediaType.APPLICATION_JSON));
             genericResponse = response.readEntity(valueType);
             response.close();
@@ -861,7 +837,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(usersToGroup),MediaType.APPLICATION_JSON));
 
             responseObject=response.readEntity(valueType);
@@ -890,7 +865,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity("",MediaType.APPLICATION_JSON));
             genericResponse = response.readEntity(valueType);
             response.close();
@@ -919,7 +893,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(userToGroups),MediaType.APPLICATION_JSON));
 
             responseObject=response.readEntity(valueType);
@@ -949,7 +922,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     post(Entity.entity(JSONUtil.convertObjectToJSON(numberProfileRequest),MediaType.APPLICATION_JSON));
 
             numberProfileResponse = response.readEntity(NumberProfileResponse.class);
@@ -980,7 +952,6 @@ public class SAExecuter {
             response = target.request().
                     accept(MediaType.APPLICATION_JSON).
                     header("Authorization", auth).
-                    header("X-SA-Date", ts).
                     put(Entity.entity(JSONUtil.convertObjectToJSON(numberProfileUpdateRequest),MediaType.APPLICATION_JSON));
 
             numberProfileUpdateResponse = response.readEntity(BaseResponse.class);


### PR DESCRIPTION
Added the Custom TimeStamp header for SA to the ClientRequestFilter
Removed all references to the setting of that header to the Client Filter
Easier to manage in on place then in every client method call