### PR TITLE
JSI-31: Mechanism to allow setting the "X-Request-ID" header for each request added

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-currentVersion=1.0.6.6
+currentVersion=1.0.6.7

--- a/src/main/java/org/secureauth/sarestapi/SAAccess.java
+++ b/src/main/java/org/secureauth/sarestapi/SAAccess.java
@@ -25,6 +25,7 @@ import org.secureauth.sarestapi.data.UserProfile.UserProfileKB;
 import org.secureauth.sarestapi.data.UserProfile.UserToGroups;
 import org.secureauth.sarestapi.data.UserProfile.UsersToGroup;
 import org.secureauth.sarestapi.exception.SARestAPIException;
+import org.secureauth.sarestapi.guid.GUIDStrategy;
 import org.secureauth.sarestapi.queries.*;
 import org.secureauth.sarestapi.resources.Resource;
 import org.secureauth.sarestapi.resources.SAExecuter;
@@ -93,6 +94,12 @@ public class SAAccess implements ISAAccess{
         saBaseURL=new SABaseURL(host,port,ssl,selfSigned);
         saAuth = new SAAuth(applicationID,applicationKey,realm);
         saExecuter=new SAExecuter(saBaseURL);
+    }
+
+    public SAAccess(String host, String port,boolean ssl,boolean selfSigned, String realm, String applicationID, String applicationKey, GUIDStrategy guidStrategy){
+        saBaseURL=new SABaseURL(host,port,ssl,selfSigned);
+        saAuth = new SAAuth(applicationID,applicationKey,realm);
+        saExecuter=new SAExecuter(saBaseURL, guidStrategy);
     }
 
     /**

--- a/src/main/java/org/secureauth/sarestapi/guid/GUIDStrategy.java
+++ b/src/main/java/org/secureauth/sarestapi/guid/GUIDStrategy.java
@@ -1,0 +1,8 @@
+package org.secureauth.sarestapi.guid;
+
+import java.util.UUID;
+
+public interface GUIDStrategy {
+
+    UUID generateRequestID();
+}

--- a/src/main/java/org/secureauth/sarestapi/guid/XRequestIDFilter.java
+++ b/src/main/java/org/secureauth/sarestapi/guid/XRequestIDFilter.java
@@ -1,0 +1,18 @@
+package org.secureauth.sarestapi.guid;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+
+public class XRequestIDFilter implements ClientRequestFilter {
+
+    private GUIDStrategy guidStrategy;
+
+    public XRequestIDFilter(GUIDStrategy guidStrategy) {
+        this.guidStrategy = guidStrategy;
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) {
+        requestContext.getHeaders().putSingle( "X-Request-ID", this.guidStrategy.generateRequestID() );
+    }
+}

--- a/src/test/java/org/secureauth/sarestapi/guid/SAAccessUnitTest.java
+++ b/src/test/java/org/secureauth/sarestapi/guid/SAAccessUnitTest.java
@@ -1,0 +1,84 @@
+package org.secureauth.sarestapi.guid;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.secureauth.sarestapi.SAAccess;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+public class SAAccessUnitTest {
+
+    private WireMockServer wireMockServer;
+    private final String X_REQUEST_ID = "X-Request-Id";
+    @Before
+    public void setup() {
+        this.wireMockServer = new WireMockServer(8090);
+        this.wireMockServer.start();
+    }
+
+    @After
+    public void teardown() {
+        this.wireMockServer.stop();
+    }
+
+    @Test
+    public void given_SAAccessWithNewRequestIDForEachRequest_When_PerformOutOfBandAuthStateful_Then_XRequestIDHeaderIsPresent() {
+        // given
+        final SAAccess saAccess = this.createSAAccessWithGUIDStrategy( UUID::randomUUID );
+        final String userId = "test-user-1";
+        final String factorId = "9a29542309654256a0d71f9e86095f45";
+        // when
+        saAccess.sendPushToAcceptReqStateful( userId, factorId, "127.0.0.1", "", "" );
+        // then
+        this.wireMockServer.verify(
+                postRequestedFor( urlEqualTo("/Realm01/api/v1/auth" ) )
+                .withHeader( X_REQUEST_ID , matching( "\\S{36}" ) )
+        );
+    }
+
+    @Test
+    public void given_SAAccessWithNewRequestIDForEachRequest_When_PerformFiveOutOfBandAuthStatefulRequests_Then_FiveDifferentXRequestIDHeaderValueAreGenerated() {
+        // given
+        final SAAccess saAccess = this.createSAAccessWithGUIDStrategy( UUID::randomUUID );
+        final String userId = "test-user-1";
+        final String factorId = "9a29542309654256a0d71f9e86095f45";
+        final int requestsToMake = 5;
+        // when
+        IntStream.range( 0, requestsToMake )
+                .forEach( i ->
+                        saAccess.sendPushToAcceptReqStateful(userId, factorId, "127.0.0.1", "", "")
+                );
+        // then
+        List<LoggedRequest> requestList = this.wireMockServer.findAll(
+                postRequestedFor( urlEqualTo("/Realm01/api/v1/auth" ) )
+                        .withHeader( X_REQUEST_ID, matching( "\\S{36}" ) )
+        );
+        Assert.assertEquals(
+                requestsToMake,
+                requestList.stream().map( r -> r.getHeader( X_REQUEST_ID ) ).collect(Collectors.toSet() ).size()
+        );
+    }
+
+    private SAAccess createSAAccessWithGUIDStrategy(GUIDStrategy guidStrategy) {
+        return new SAAccess(
+                "localhost",
+                "8090",
+                false,
+                true,
+                "Realm01",
+                "Realm01-ApplicationId",
+                "Realm01-ApplicationKey",
+                guidStrategy
+        );
+    }
+}
+


### PR DESCRIPTION
**Description** : Add a mechanism to allow setting the "X-Request-ID" header for each request.

### Last Param in SAAccess constructor an GUIDStrategy object

Clients would implement the following interface or use a lambda function (see example bellow or tests added in this pull request).

```
public interface GUIDStrategy {

    UUID generateRequestID();
}
```

**Example** : A new X-Request-ID is generated for each new request.

new SAAccess(
                "localhost",
                "8090",
                false,
                true,
                "Realm01",
                "Realm01-ApplicationId",
                "Realm01-ApplicationKey",
                UUID::randomUUID // lambda function.
);



